### PR TITLE
(#3) Revising product line page to fill measures when product changes

### DIFF
--- a/new/schema/views/vw_products_with_measures.sql
+++ b/new/schema/views/vw_products_with_measures.sql
@@ -1,0 +1,7 @@
+DROP VIEW IF EXISTS vw_products_with_measures;
+
+CREATE VIEW vw_products_with_measures AS
+SELECT
+  t1.id AS product_id, t1.product_name, t1.product_type_id, t2.id AS measure_id, t2.product_measure_name
+FROM sys_products t1
+INNER JOIN sys_product_measures t2 ON t1.product_type_id=t2.product_type_id;


### PR DESCRIPTION
New view that joins the product with its available measure via the product type.  Used to set the measures ddl on the product lines page when the product changes.
