### PR TITLE
(#12) Added the vendors product id to the views

### DIFF
--- a/new/schema/views/vw_order_lines.sql
+++ b/new/schema/views/vw_order_lines.sql
@@ -6,6 +6,7 @@ SELECT
   t1.id AS ruid,
   t1.vendor_id,
   t1.product_id,
+  t2.vendor_product_id,
   t2.product_name,
   t1.product_type_id,
   t3.product_type_name,

--- a/new/schema/views/vw_product_lines_with_descs.sql
+++ b/new/schema/views/vw_product_lines_with_descs.sql
@@ -5,6 +5,7 @@ SELECT
   t1.id, 
   t2.vendor_id, 
   t1.product_id, 
+  t2.vendor_product_id, 
   t2.product_name, 
   t1.product_measure_id, 
   t3.product_measure_name,


### PR DESCRIPTION
Revised the vw_order_lines and vw_product_lines_with_descs to include the vendor product id.  Joins across to item (#25) on the portal where the orders, order accept and order complete pages were showing an incorrect id.
