### PR TITLE
(#34) Added a new vendor system settings page/db to hold, timeslots, orders in slots etc

### DIFF
--- a/new/data/demo/vendor-settings-DATA.sql
+++ b/new/data/demo/vendor-settings-DATA.sql
@@ -1,0 +1,3 @@
+
+INSERT INTO sys_vendor_settings (vendor_id, timeslot_length, timeslot_maxorders, order_alert, review_maxscore, review_showcount, is_active) VALUES (1, 5, 5, 5, 7, 5, 1);
+INSERT INTO sys_vendor_settings (vendor_id, timeslot_length, timeslot_maxorders, order_alert, review_maxscore, review_showcount, is_active) VALUES (2, 15, 10, 15, 5, 10, 1);

--- a/new/schema/tables/sys_vendor_settings.sql
+++ b/new/schema/tables/sys_vendor_settings.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS sys_vendor_settings;
+
+CREATE TABLE sys_vendor_settings
+(
+  id int not null auto_increment,
+  vendor_id INT,
+  timeslot_length INT,
+  timeslot_maxorders INT,
+  order_alert INT,
+  review_maxscore INT,
+  review_showcount INT,
+  is_active BIT,
+  PRIMARY KEY (id)
+);

--- a/new/schema/views/dv_sys_vendor_settings.sql
+++ b/new/schema/views/dv_sys_vendor_settings.sql
@@ -1,0 +1,6 @@
+DROP VIEW IF EXISTS dv_sys_vendor_settings;
+
+CREATE VIEW dv_sys_vendor_settings AS 
+SELECT * 
+FROM sys_vendor_settings
+ORDER BY id ASC;


### PR DESCRIPTION
These are a new table and view that will hold various settings such as time slot size, number of orders in each timeslot, review settings etc.

There is also a small data script to add some settings for vendors 1 and 2.
